### PR TITLE
uninstall logilab-common before installing pylint, this will make sur…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 install:
+	pip uninstall logilab-common
 	pip install -i http://pip-repo/simple/ --extra-index-url http://mirrors.stratoscale.com.s3-website-us-east-1.amazonaws.com/pip/simple --trusted-host mirrors.stratoscale.com.s3-website-us-east-1.amazonaws.com --trusted-host pip-repo --requirement requirements.txt


### PR DESCRIPTION
…e the correct version of logilab is used
